### PR TITLE
remove reference to a redundant config

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,8 +21,8 @@ func main() {
 	undo := zap.ReplaceGlobals(logger)
 	defer undo()
 
-	if !strings.HasSuffix(viper.GetString("CONFIG_DIRECTORY_PATH"), "/") {
-		zap.S().Fatalw("CONFIG_DIRECTORY_PATH must have a trailing slash /", "CONFIG_DIRECTORY_PATH", viper.GetString("CONFIG_DIRECTORY_PATH"))
+	if !strings.HasSuffix(viper.GetString("MANAGED_OBJECTS_DIRECTORY_PATH"), "/") {
+		zap.S().Fatalw("MANAGED_OBJECTS_DIRECTORY_PATH must have a trailing slash /", "MANAGED_OBJECTS_DIRECTORY_PATH", viper.GetString("MANAGED_OBJECTS_DIRECTORY_PATH"))
 	}
 
 	if !platform.IsValidX509() {


### PR DESCRIPTION
`CONFIG_DIRECTORY_PATH ` has been replaced with `MANAGED_OBJECTS_DIRECTORY_PATH `.
The morning build failed this morning due to the reference to the redundant config
https://g.codefresh.io/build/60a3574d13dcb14366bee564?step=ig&tab=output&logs=terminal