### PR TITLE
fix typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,6 @@ endif
 	docker build -t eu.gcr.io/${gcr-repo}/securebanking/${service}:${tag} .
 	docker push eu.gcr.io/${gcr-repo}/securebanking/${service}:${tag}
 ifdef release-repo
-	docker tag eu.gcr.io/${gcr-repo}/securebanking/${service}:${tag} eu.gcr.io/${release-repo}/securebanking-ui/${service}:${tag}
+	docker tag eu.gcr.io/${gcr-repo}/securebanking/${service}:${tag} eu.gcr.io/${release-repo}/securebanking/${service}:${tag}
 	docker push eu.gcr.io/${release-repo}/securebanking/${service}:${tag}
 endif


### PR DESCRIPTION
fixes a typo in the makefile that was preventing the merge action from pushing to the release repo.

issue: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer/issues/19