### PR TITLE
build develop container

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,3 +19,15 @@ jobs:
       - name: Run Tests
         run: |
           make test-ci
+      
+      - uses: google-github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.GCR_KEY }}
+          export_default_credentials: true
+        # Configure docker to use the gcloud command-line tool as a credential helper
+      - run: |
+          gcloud auth configure-docker
+
+      - name: docker build
+        run: |
+          make docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13.0
 
-RUN apk --no-cache add curl
+RUN apk --no-cache add curl libc6-compat
 RUN addgroup -S sob-group && adduser -S sob-user -G sob-group
 
 RUN mkdir -p "/opt/sob/config"


### PR DESCRIPTION
Fix failure in the way the go binary is build in github actions.
There was a strange error in the morning build: https://g.codefresh.io/build/60c9ad5da876e95a218ebe31?step=ig&tab=output&logs=terminal

Tracked it down to a dynamic link failure described [here](https://stackoverflow.com/a/66974607). 