### PR TITLE
restartPolicy to OnFailure

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-fidc-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-fidc-initializer/templates/cronjob.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   schedule: "{{ .Values.cron }}"
   concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:
@@ -37,4 +38,4 @@ spec:
                   sleep 10
                   done
                   ./setup
-          restartPolicy: Always
+          restartPolicy: OnFailure


### PR DESCRIPTION
Change restart policy to `OnFailure`. The documentation suggests that `Always` is supported for `v1beta1` but this isnt the case.

Also add a `successfulJobsHistoryLimit` of 1 to reduce the namespace noise

issue: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer/issues/25