### PR TITLE
Change cm key to FQDN

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-fidc-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-fidc-initializer/templates/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
                 valueFrom:
                   configMapKeyRef:
                     name: platform-config
-                    key: IAM_FQDN
+                    key: FQDN
               - name: REQUEST_BODY_PATH
                 value: config/
               command: ["/bin/sh", "-c"]


### PR DESCRIPTION
The default config created by the CDK deployment is `FQDN` not `IAM_FQDN`.
`IAM_FQDN` was added as part of the "IG" way of deploying the configurator. it is no longer relevant.

issue: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer/issues/25