### PR TITLE
Fix for issue 210 - duplicate service accounts

### DIFF
--- a/am/serviceaccount-test.json
+++ b/am/serviceaccount-test.json
@@ -1,37 +1,5 @@
 {
-  "result": [
-    {
-      "_id": "123",
-      "_rev": "456",
-      "cn": [
-        "Policy Engine Service Account"
-      ],
-      "mail": [
-        "example@example.com"
-      ],
-      "username": "service_account.policy",
-      "inetUserStatus": [
-        "Active"
-      ]
-    },
-    {
-      "_id": "124",
-      "_rev": "876",
-      "cn": [
-        "IG Service Account"
-      ],
-      "mail": [
-        "ig@acme.com"
-      ],
-      "username": "service_account.ig",
-      "inetUserStatus": [
-        "Active"
-      ]
-    }
-  ],
-  "resultCount": 2,
-  "pagedResultsCookie": null,
-  "totalPagedResultsPolicy": "NONE",
-  "totalPagedResults": -1,
-  "remainingPagedResults": 0
+  "_id": "service_account.ig",
+  "_rev": "0000000099ad635d",
+  "username": "service_account.ig"
 }

--- a/am/serviceaccount.go
+++ b/am/serviceaccount.go
@@ -131,8 +131,8 @@ func CreateIDMAdminClient(cookie *http.Cookie) {
 //   When CDK is removed, these entities might still be persisted. this gives us
 //   an indication that we do not need to initialize the environment
 func ServiceIdentityExists(identity string) bool {
-	path := "/am/json/realms/root/realms/alpha/users?_queryFilter=true&_pageSize=10&_fields=cn,mail,username,inetUserStatus"
-	serviceIdentity := &AmResult{}
+	path := "/am/json/realms/root/realms/alpha/users/" + identity + "?_fields=username"
+	serviceIdentity := &Result{}
 	b := Client.Get(path, map[string]string{
 		"Accept":             "application/json",
 		"X-Requested-With":   "ForgeRock Identity Cloud Postman Collection",
@@ -143,8 +143,5 @@ func ServiceIdentityExists(identity string) bool {
 	if err != nil {
 		panic(err)
 	}
-
-	return Find(identity, serviceIdentity, func(r *Result) string {
-		return r.Username
-	})
+	return serviceIdentity.Username == identity
 }


### PR DESCRIPTION
Modified query that checks if an identity exists. Also modified the mock response for the test suite with a real example of response for spcific account query.