### PR TITLE
217: CDK service users initialisation fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ setup
 .vscode/
 pacts/
 logs/
+pact/

--- a/am/alpha.go
+++ b/am/alpha.go
@@ -27,7 +27,7 @@ func CreateAlphaRealm(cookie *http.Cookie) {
 		SetCookie(cookie).
 		SetBody(b).
 		Post(path)
-	common.RaiseForStatus(err, resp.Error())
+	common.RaiseForStatus(err, resp.Error(), resp.Status())
 
 	zap.S().Infow("Alpha Realm Created", "statusCode", resp.StatusCode())
 }
@@ -55,12 +55,14 @@ func AlphaRealmExists(cookie *http.Cookie) bool {
 func AlphaClientsExist(clientName string) bool {
 	path := "/am/json/realms/root/realms/alpha/realm-config/agents/OAuth2Client?_queryFilter=true&_pageSize=10&_fields=coreOAuth2ClientConfig/status,coreOAuth2ClientConfig/agentgroup"
 	result := &AmResult{}
-	b := Client.Get(path, map[string]string{
+	b, status := Client.Get(path, map[string]string{
 		"Accept":             "application/json",
 		"X-Requested-With":   "ForgeRock Identity Cloud Postman Collection",
 		"Accept-Api-Version": "protocol=2.0,resource=1.0",
 	})
-
+	if status == http.StatusNotFound {
+		return false
+	}
 	err := json.Unmarshal(b, result)
 	if err != nil {
 		panic(err)

--- a/am/alpha_test.go
+++ b/am/alpha_test.go
@@ -16,7 +16,7 @@ func TestFindExistingAlphaClient(t *testing.T) {
 	mockRestReaderWriter.On("Get", mock.Anything, mock.Anything).
 		Return(buffer)
 
-	b := AlphaClientsExist("Doesnt existy")
+	b := AlphaClientsExist("Doesn't exist")
 	assert.False(t, b)
 	mockRestReaderWriter.AssertCalled(t, "Get", mock.Anything, mock.Anything)
 

--- a/am/client.go
+++ b/am/client.go
@@ -9,7 +9,7 @@ import (
 )
 
 type RestReaderWriter interface {
-	Get(string, map[string]string) []byte
+	Get(string, map[string]string) ([]byte, int)
 	Patch(string, interface{}, map[string]string) int
 	Post(string, interface{}, map[string]string) int
 	Put(string, interface{}, map[string]string) int
@@ -33,13 +33,18 @@ func InitRestReaderWriter(cookie *http.Cookie, authCode string) {
 	}
 }
 
-func (r *RestClient) Get(path string, headers map[string]string) []byte {
+func (r *RestClient) Get(path string, headers map[string]string) ([]byte, int) {
 	resp, err := r.request(headers).
 		Get(r.FQDN + path)
 
-	common.RaiseForStatus(err, resp.Error())
+	// return the status code as String to check the status
+	//if resp.StatusCode() != http.StatusOK {
+	//	return []byte(resp.Status())
+	//}
 
-	return resp.Body()
+	common.RaiseForStatus(err, resp.Error(), resp.Status())
+
+	return resp.Body(), resp.StatusCode()
 }
 
 func (r *RestClient) request(headers map[string]string) *resty.Request {
@@ -55,7 +60,7 @@ func (r *RestClient) Post(path string, ob interface{}, headers map[string]string
 		SetContentLength(true).
 		Post(r.FQDN + path)
 
-	common.RaiseForStatus(err, resp.Error())
+	common.RaiseForStatus(err, resp.Error(), resp.Status())
 
 	return resp.StatusCode()
 }
@@ -65,7 +70,7 @@ func (r *RestClient) Patch(path string, ob interface{}, headers map[string]strin
 		SetBody(ob).
 		Patch(r.FQDN + path)
 
-	common.RaiseForStatus(err, resp.Error())
+	common.RaiseForStatus(err, resp.Error(), resp.Status())
 
 	return resp.StatusCode()
 }
@@ -76,7 +81,7 @@ func (r *RestClient) Put(path string, ob interface{}, headers map[string]string)
 		SetContentLength(true).
 		Put(r.FQDN + path)
 
-	common.RaiseForStatus(err, resp.Error())
+	common.RaiseForStatus(err, resp.Error(), resp.Status())
 
 	return resp.StatusCode()
 }

--- a/am/idm.go
+++ b/am/idm.go
@@ -30,7 +30,7 @@ func ObjectNames(relativePath string) []string {
 func MissingObjects(objectNames []string) []string {
 	path := "/openidm/config/managed"
 	result := &OBManagedObjects{}
-	b := Client.Get(path, map[string]string{
+	b, _ := Client.Get(path, map[string]string{
 		"Accept":           "application/json",
 		"X-Requested-With": "ForgeRock Identity Cloud Postman Collection",
 	})

--- a/am/oauth2.go
+++ b/am/oauth2.go
@@ -96,7 +96,7 @@ func CreateRemoteConsentService() {
 func RemoteConsentExists(name string) bool {
 	path := "/am/json/realms/root/realms/alpha/realm-config/agents/RemoteConsentAgent?_queryFilter=true&_pageSize=10&_fields=agentgroup"
 	consent := &AmResult{}
-	b := Client.Get(path, map[string]string{
+	b, _ := Client.Get(path, map[string]string{
 		"Accept":             "application/json",
 		"X-Requested-With":   "ForgeRock Identity Cloud Postman Collection",
 		"Accept-Api-Version": "protocol=2.0,resource=1.0",
@@ -209,7 +209,7 @@ func CreateSoftwarePublisherAgentTestPublisher() {
 func SoftwarePublisherAgentExists(name string) bool {
 	path := "/am/json/realms/root/realms/alpha/realm-config/agents/SoftwarePublisher?_queryFilter=true&_pageSize=10&_fields=agentgroup"
 	agent := &AmResult{}
-	b := Client.Get(path, map[string]string{
+	b, _ := Client.Get(path, map[string]string{
 		"Accept":             "application/json",
 		"X-Requested-With":   "ForgeRock Identity Cloud Postman Collection",
 		"Accept-Api-Version": "protocol=2.0,resource=1.0",
@@ -251,7 +251,7 @@ func CreateOIDCClaimsScript(cookie *http.Cookie) string {
 		SetBody(b).
 		Post(path)
 
-	common.RaiseForStatus(err, resp.Error())
+	common.RaiseForStatus(err, resp.Error(), resp.Status())
 
 	zap.S().Infow("OIDC claims script", "statusCode", resp.StatusCode(), "claimsScriptID", claimsScript.ID, "createdBy", claimsScript.CreatedBy)
 	return claimsScript.ID
@@ -260,7 +260,7 @@ func CreateOIDCClaimsScript(cookie *http.Cookie) string {
 func GetScriptIdByName(name string) string {
 	path := "/am/json/alpha/scripts?_pageSize=20&_sortKeys=name&_queryFilter=true&_pagedResultsOffset=0"
 	consent := &AmResult{}
-	b := Client.Get(path, map[string]string{
+	b, _ := Client.Get(path, map[string]string{
 		"Accept":             "application/json",
 		"X-Requested-With":   "ForgeRock Identity Cloud Postman Collection",
 		"Accept-Api-Version": "protocol=1.0,resource=1.0",
@@ -308,7 +308,7 @@ func UpdateOAuth2Provider(claimsScriptID string) {
 func Oauth2ProviderExists(id string) bool {
 	path := "/am/json/realms/root/realms/alpha/realm-config/services?_queryFilter=true"
 	r := &AmResult{}
-	b := Client.Get(path, map[string]string{
+	b, _ := Client.Get(path, map[string]string{
 		"Accept":             "application/json",
 		"X-Requested-With":   "ForgeRock Identity Cloud Postman Collection",
 		"Accept-Api-Version": "protocol=1.0,resource=1.0",

--- a/am/oauth2.go
+++ b/am/oauth2.go
@@ -96,12 +96,14 @@ func CreateRemoteConsentService() {
 func RemoteConsentExists(name string) bool {
 	path := "/am/json/realms/root/realms/alpha/realm-config/agents/RemoteConsentAgent?_queryFilter=true&_pageSize=10&_fields=agentgroup"
 	consent := &AmResult{}
-	b, _ := Client.Get(path, map[string]string{
+	b, status := Client.Get(path, map[string]string{
 		"Accept":             "application/json",
 		"X-Requested-With":   "ForgeRock Identity Cloud Postman Collection",
 		"Accept-Api-Version": "protocol=2.0,resource=1.0",
 	})
-
+	if status == http.StatusNotFound {
+		return false
+	}
 	err := json.Unmarshal(b, consent)
 	if err != nil {
 		panic(err)
@@ -209,12 +211,14 @@ func CreateSoftwarePublisherAgentTestPublisher() {
 func SoftwarePublisherAgentExists(name string) bool {
 	path := "/am/json/realms/root/realms/alpha/realm-config/agents/SoftwarePublisher?_queryFilter=true&_pageSize=10&_fields=agentgroup"
 	agent := &AmResult{}
-	b, _ := Client.Get(path, map[string]string{
+	b, status := Client.Get(path, map[string]string{
 		"Accept":             "application/json",
 		"X-Requested-With":   "ForgeRock Identity Cloud Postman Collection",
 		"Accept-Api-Version": "protocol=2.0,resource=1.0",
 	})
-
+	if status == http.StatusNotFound {
+		return false
+	}
 	err := json.Unmarshal(b, agent)
 	if err != nil {
 		panic(err)
@@ -308,12 +312,14 @@ func UpdateOAuth2Provider(claimsScriptID string) {
 func Oauth2ProviderExists(id string) bool {
 	path := "/am/json/realms/root/realms/alpha/realm-config/services?_queryFilter=true"
 	r := &AmResult{}
-	b, _ := Client.Get(path, map[string]string{
+	b, status := Client.Get(path, map[string]string{
 		"Accept":             "application/json",
 		"X-Requested-With":   "ForgeRock Identity Cloud Postman Collection",
 		"Accept-Api-Version": "protocol=1.0,resource=1.0",
 	})
-
+	if status == http.StatusNotFound {
+		return false
+	}
 	err := json.Unmarshal(b, r)
 	if err != nil {
 		panic(err)

--- a/am/policy.go
+++ b/am/policy.go
@@ -85,7 +85,7 @@ func CreatePolicyEvaluationScript(cookie *http.Cookie) string {
 		SetBody(policyScript).
 		Post(path)
 
-	common.RaiseForStatus(err, resp.Error())
+	common.RaiseForStatus(err, resp.Error(), resp.Status())
 
 	zap.S().Infow("Policy Evaluation Script", "statusCode", resp.StatusCode(), "scriptId", scriptBody.ID)
 	return scriptBody.ID
@@ -124,12 +124,14 @@ func CreateOpenBankingPolicySet() {
 func PolicySetExists(name string) bool {
 	path := "/am/json/alpha/applications?_pageSize=20&_sortKeys=name&_queryFilter=name+eq+%22%5E(%3F!sunAMDelegationService%24).*%22&_pagedResultsOffset=0"
 	serviceIdentity := &AmResult{}
-	b := Client.Get(path, map[string]string{
+	b, status := Client.Get(path, map[string]string{
 		"Accept":             "application/json",
 		"X-Requested-With":   "ForgeRock Identity Cloud Postman Collection",
 		"Accept-Api-Version": "protocol=1.0,resource=2.0",
 	})
-
+	if status == http.StatusNotFound {
+		return false
+	}
 	err := json.Unmarshal(b, serviceIdentity)
 	if err != nil {
 		panic(err)
@@ -143,12 +145,14 @@ func PolicySetExists(name string) bool {
 func PolicyExists(name string) bool {
 	path := "/am/json/alpha/policies?_pageSize=20&_sortKeys=name&_queryFilter=applicationName+eq+%22Open%20Banking%22&_pagedResultsOffset=0"
 	serviceIdentity := &AmResult{}
-	b := Client.Get(path, map[string]string{
+	b, status := Client.Get(path, map[string]string{
 		"Accept":             "application/json",
 		"X-Requested-With":   "ForgeRock Identity Cloud Postman Collection",
 		"Accept-Api-Version": "protocol=1.0,resource=2.0",
 	})
-
+	if status == http.StatusNotFound {
+		return false
+	}
 	err := json.Unmarshal(b, serviceIdentity)
 	if err != nil {
 		panic(err)

--- a/am/serviceaccount.go
+++ b/am/serviceaccount.go
@@ -122,7 +122,7 @@ func CreateIDMAdminClient(cookie *http.Cookie) {
 		SetBody(config).
 		Put(path)
 
-	common.RaiseForStatus(err, resp.Error())
+	common.RaiseForStatus(err, resp.Error(), resp.Status())
 
 	zap.S().Infow("IDM Admin Client", "statusCode", resp.StatusCode(), "redirect", config.CoreOAuth2ClientConfig.RedirectionUris.Value)
 }
@@ -133,12 +133,14 @@ func CreateIDMAdminClient(cookie *http.Cookie) {
 func ServiceIdentityExists(identity string) bool {
 	path := "/am/json/realms/root/realms/alpha/users/" + identity + "?_fields=username"
 	serviceIdentity := &Result{}
-	b := Client.Get(path, map[string]string{
+	b, status := Client.Get(path, map[string]string{
 		"Accept":             "application/json",
 		"X-Requested-With":   "ForgeRock Identity Cloud Postman Collection",
 		"Accept-Api-Version": "protocol=2.1, resource=4.0",
 	})
-
+	if status == http.StatusNotFound {
+		return false
+	}
 	err := json.Unmarshal(b, serviceIdentity)
 	if err != nil {
 		panic(err)

--- a/am/system_clients.go
+++ b/am/system_clients.go
@@ -38,7 +38,7 @@ func ApplySystemClients(cookie *http.Cookie) {
 		SetBody(config).
 		Put(path)
 
-	common.RaiseForStatus(err, resp.Error())
+	common.RaiseForStatus(err, resp.Error(), resp.Status())
 
 	zap.S().Infow("oauth2 system Client", "statusCode", resp.StatusCode(), "redirect", config.CoreOAuth2ClientConfig.RedirectionUris.Value)
 }

--- a/common/error.go
+++ b/common/error.go
@@ -16,16 +16,17 @@ type RestError struct {
 // RaiseForStatus will exit if go resty returns an error in STRICT mode,
 //    Be it client error, server error or other. Turning off
 //    STRICT mode will simply warn of client/server errors.
-func RaiseForStatus(err error, restError interface{}) {
+func RaiseForStatus(err error, restError interface{}, status string) {
 	if err != nil {
-		zap.S().Fatalw("Goresty has thrown an error when attempting to send", "error", err)
+		zap.S().Fatalw("Go rest has thrown an error when attempting to send", "error", err, "httpStatus", status)
 	}
 
 	if restError != nil {
 		strict := viper.GetBool("STRICT")
 		if strict {
-			zap.S().Fatalw("Goresty has sent the request but the status is > 399", "error", restError)
+			zap.S().Fatalw("Go rest has sent the request but the status is > 399", "error", restError, "httpStatus", status)
 		}
-		zap.S().Warnw("Goresty has sent the request but the status is > 399", "error", restError)
+		zap.S().Warnw("Go rest has sent the request but the status is > 399", "error", restError, "httpStatus", status)
 	}
 }
+

--- a/mocks/am/RestReaderWriter.go
+++ b/mocks/am/RestReaderWriter.go
@@ -10,7 +10,7 @@ type RestReaderWriter struct {
 }
 
 // Get provides a mock function with given fields: _a0, _a1
-func (_m *RestReaderWriter) Get(_a0 string, _a1 map[string]string) []byte {
+func (_m *RestReaderWriter) Get(_a0 string, _a1 map[string]string) ([]byte,int) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 []byte
@@ -22,7 +22,7 @@ func (_m *RestReaderWriter) Get(_a0 string, _a1 map[string]string) []byte {
 		}
 	}
 
-	return r0
+	return r0, 200
 }
 
 // Patch provides a mock function with given fields: _a0, _a1, _a2

--- a/platform/authenticate.go
+++ b/platform/authenticate.go
@@ -50,7 +50,7 @@ func GetCookieNameFromAm() string {
 		SetHeader("Accept", "application/json").
 		SetResult(result).
 		Get(path)
-	common.RaiseForStatus(err, resp.Error())
+	common.RaiseForStatus(err, resp.Error(), resp.Status())
 
 	cookieName := result.Cookiename
 
@@ -69,7 +69,7 @@ func FromUserSession(cookieName string) *Session {
 		SetHeader("X-OpenAM-Username", viper.GetString("OPEN_AM_USERNAME")).
 		SetHeader("X-OpenAM-Password", viper.GetString("OPEN_AM_PASSWORD")).
 		Post(path)
-	common.RaiseForStatus(err, resp.Error())
+	common.RaiseForStatus(err, resp.Error(), resp.Status())
 
 	var cookieValue string = ""
 	for _, cookie := range resp.Cookies() {
@@ -152,6 +152,6 @@ func (s *Session) GetIDMAdminToken() {
 			"code_verifier": "codeverifier",
 		}).
 		Post(path)
-	common.RaiseForStatus(err, resp.Error())
+	common.RaiseForStatus(err, resp.Error(), resp.Status())
 	s.AuthToken = *token
 }


### PR DESCRIPTION
- Added pair return on the rest client to catch the http status
- Improved the errors with the http status
- Added a condicional in exist methods to check the http status to check if the object exist (false when 404 is returned)
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/217