### PR TITLE
Add the endpoints for each env in the acceptable audience of the OAuth2Provider

### DIFF
--- a/config/defaults/secure-open-banking/oauth2provider-update.json
+++ b/config/defaults/secure-open-banking/oauth2provider-update.json
@@ -54,7 +54,16 @@
       "token|org.forgerock.oauth2.core.TokenResponseTypeHandler"
     ],
     "tokenCompressionEnabled": false,
-    "allowedAudienceValues": [],
+    "allowedAudienceValues": [
+      "https://obdemo.dev.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
+      "https://obdemo.nightly.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
+      "https://obdemo.andra-racovita.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
+      "https://obdemo.mariantiris.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
+      "https://obdemo.christian-brindley.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
+      "https://obdemo.bohocode.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
+      "https://obdemo.jorgesanchezperez.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
+      "https://obdemo.joycegilding-forgerock.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token"
+    ],
     "scopeImplementationClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
     "tlsCertificateRevocationCheckingEnabled": false
   },


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/255

I have added the endpoints for each environment in the Acceptable Audience Values field from the OAuth2 Provider.
`
"allowedAudienceValues": [
      "https://obdemo.dev.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
      "https://obdemo.nightly.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
      "https://obdemo.andra-racovita.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
      "https://obdemo.mariantiris.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
      "https://obdemo.christian-brindley.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
      "https://obdemo.bohocode.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
      "https://obdemo.jorgesanchezperez.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
      "https://obdemo.joycegilding-forgerock.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token"
    ]
`

The file that I have modified is oauth2-provider-update.json locate in config/defaults/secure-open-banking.