### PR TITLE
Create the manage object for Domestic Scheduled Payment Intent

### DIFF
--- a/config/defaults/secure-open-banking/managed-objects/domesticScheduledPaymentIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/domesticScheduledPaymentIntent.json
@@ -1,0 +1,1003 @@
+[
+  {
+    "operation": "add",
+    "field": "objects/-",
+    "value": {
+      "name": "domesticScheduledPaymentIntent",
+      "schema": {
+        "$schema": "http://forgerock.org/json-schema#",
+        "type": "object",
+        "title": "Domestic Scheduled Payment Intent",
+        "description": "Domestic Scheduled Payment Intent",
+        "icon": "fa-money",
+        "properties": {
+          "Data": {
+            "title": "Data",
+            "type": "object",
+            "viewable": true,
+            "searchable": true,
+            "userEditable": true,
+            "description": null,
+            "isVirtual": false,
+            "nullable": false,
+            "properties": {
+              "ConsentId": {
+                "title": "Scheduled Payment Intent Id",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "minLength": 1,
+                "maxLength": 128,
+                "description": "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource.",
+                "nullable": false
+              },
+              "CreationDateTime": {
+                "title": "Creation Date Time",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Date and time at which the resource was created.",
+                "nullable": false
+              },
+              "Permission": {
+                "title": "Permission",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "description": "Specifies the Open Banking service request types.",
+                "userEditable": true,
+                "nullable": false
+              },
+              "Status": {
+                "title": "Scheduled Payment Intent Status",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Scheduled Payment Intent Status",
+                "isVirtual": false,
+                "nullable": false
+              },
+              "StatusUpdateDateTime": {
+                "title": "Status Update Date Time",
+                "type": "string",
+                "viewable": true,
+                "searchable": true,
+                "userEditable": true,
+                "description": "Date and time at which the consent resource status was updated.",
+                "isVirtual": false,
+                "nullable": false
+              },
+              "ExpectedExecutionDateTime": {
+                "title": "Expected Execution Date Time",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": "Expected execution date and time for the payment resource.",
+                "isVirtual": false
+              },
+              "ExpectedSettlementDateTime": {
+                "title": "Expected Settlement Date Time",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": "Expected settlement date and time for the payment resource.",
+                "isVirtual": false
+              },
+              "CutOffDateTime": {
+                "title": "Cut Off Date Time",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": "Specified cut-off date and time for the payment consent.",
+                "isVirtual": false
+              },
+              "ReadRefundAccount": {
+                "title": "Read Refund Account",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": "Specifies to share the refund account details with PISP",
+                "isVirtual": false
+              },
+              "Charges": {
+                "title": "Charges",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": null,
+                "minLength": null,
+                "isVirtual": false
+              },
+              "Initiation": {
+                "title": "Initiation",
+                "type": "object",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "properties": {
+                  "InstructionIdentification": {
+                    "title": "Instruction Identification",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.",
+                    "minLength": 1,
+                    "maxLength": 35,
+                    "isVirtual": false,
+                    "nullable": false
+                  },
+                  "EndToEndIdentification": {
+                    "title": "End To End Identification",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.",
+                    "minLength": 1,
+                    "maxLength": 35,
+                    "isVirtual": false
+                  },
+                  "LocalInstrument": {
+                    "title": "Local Instrument",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "User community specific instrument.",
+                    "isVirtual": false
+                  },
+                  "RequestedExecutionDateTime": {
+                    "title": "Requested Execution Date Time",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "Date at which the initiating party requests the clearing agent to process the payment. ",
+                    "nullable": false,
+                    "isVirtual": false
+                  },
+                  "InstructedAmount": {
+                    "title": "Instructed Amount",
+                    "type": "object",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "properties": {
+                      "Amount": {
+                        "title": "Amount",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.",
+                        "isVirtual": false
+                      },
+                      "Currency": {
+                        "title": "Currency",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\".",
+                        "isVirtual": false
+                      }
+                    },
+                    "order": [
+                      "Amount",
+                      "Currency"
+                    ],
+                    "description": "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.",
+                    "isVirtual": false,
+                    "required": [
+                      "Amount",
+                      "Currency"
+                    ],
+                    "nullable": false
+                  },
+                  "DebtorAccount": {
+                    "title": "Debtor Account",
+                    "type": "object",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "properties": {
+                      "Identification": {
+                        "title": "Identification",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner.",
+                        "maxLength": 256,
+                        "isVirtual": false,
+                        "nullable": false
+                      },
+                      "Name": {
+                        "title": "Name",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Name of the account, as assigned by the account servicing institution.  Usage The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.",
+                        "isVirtual": false
+                      },
+                      "SchemeName": {
+                        "title": "Scheme Name",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Name of the identification scheme, in a coded form as published in an external list.",
+                        "isVirtual": false,
+                        "nullable": false
+                      },
+                      "SecondaryIdentification": {
+                        "title": "Secondary Identification",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)",
+                        "maxLength": 34,
+                        "isVirtual": false
+                      }
+                    },
+                    "order": [
+                      "SchemeName",
+                      "Identification",
+                      "Name",
+                      "SecondaryIdentification"
+                    ],
+                    "required": [
+                      "SchemeName",
+                      "Identification"
+                    ],
+                    "description": "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction.",
+                    "isVirtual": false
+                  },
+                  "CreditorAccount": {
+                    "title": "Creditor Account",
+                    "type": "object",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "properties": {
+                      "Identification": {
+                        "title": "Identification",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner.",
+                        "maxLength": 256,
+                        "isVirtual": false,
+                        "nullable": false
+                      },
+                      "Name": {
+                        "title": "Name",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Name of the account, as assigned by the account servicing institution.  Usage The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.",
+                        "isVirtual": false,
+                        "nullable": false
+                      },
+                      "SchemeName": {
+                        "title": "Scheme Name",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Name of the identification scheme, in a coded form as published in an external list.",
+                        "isVirtual": false,
+                        "nullable": false
+                      },
+                      "SecondaryIdentification": {
+                        "title": "Secondary Identification",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)",
+                        "maxLength": 34,
+                        "isVirtual": false
+                      }
+                    },
+                    "order": [
+                      "SchemeName",
+                      "Identification",
+                      "Name",
+                      "SecondaryIdentification"
+                    ],
+                    "description": "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction.",
+                    "isVirtual": false,
+                    "required": [
+                      "SchemeName",
+                      "Identification",
+                      "Name"
+                    ],
+                    "nullable": false
+                  },
+                  "CreditorPostalAddress": {
+                    "title": "Creditor Postal Address",
+                    "type": "object",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "properties": {
+                      "AddressType": {
+                        "title": "Address Type",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Identifies the nature of the postal address.",
+                        "isVirtual": false
+                      },
+                      "Department": {
+                        "title": "Department",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Identification of a division of a large organisation or building.",
+                        "minLength": 1,
+                        "maxLength": 70,
+                        "isVirtual": false
+                      },
+                      "SubDepartment": {
+                        "title": "SubDepartment",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Identification of a sub-division of a large organisation or building.",
+                        "minLength": 1,
+                        "maxLength": 70,
+                        "isVirtual": false
+                      },
+                      "StreetName": {
+                        "title": "Street Name",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Name of a street or thoroughfare.",
+                        "minLength": 1,
+                        "maxLength": 70,
+                        "isVirtual": false
+                      },
+                      "BuildingNumber": {
+                        "title": "Building Number",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Number that identifies the position of a building on a street.",
+                        "minLength": 1,
+                        "maxLength": 16,
+                        "isVirtual": false,
+                        "isVirtual": false
+                      },
+                      "PostCode": {
+                        "title": "Post Code",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail.",
+                        "minLength": 1,
+                        "maxLength": 16,
+                        "isVirtual": false
+                      },
+                      "TownName": {
+                        "title": "Town Name",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Name of a built-up area, with defined boundaries, and a local government.",
+                        "minLength": 1,
+                        "maxLength": 35,
+                        "isVirtual": false
+                      },
+                      "CountrySubDivision": {
+                        "title": "Country Sub Division",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Identifies a subdivision of a country such as state, region, county.",
+                        "minLength": 1,
+                        "maxLength": 35,
+                        "isVirtual": false
+                      },
+                      "Country": {
+                        "title": "Country",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Nation with its own government.",
+                        "isVirtual": false
+                      },
+                      "AddressLine": {
+                        "title": "Address Line",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Information that locates and identifies a specific address, as defined by postal services, presented in free format text.",
+                        "minLength": 1,
+                        "maxLength": 70,
+                        "isVirtual": false
+                      }
+                    },
+                    "order": [
+                      "AddressType",
+                      "Department",
+                      "SubDepartment",
+                      "StreetName",
+                      "BuildingNumber",
+                      "PostCode",
+                      "TownName",
+                      "CountrySubDivision",
+                      "Country",
+                      "AddressLine"
+                    ],
+                    "description": "Information that locates and identifies a specific address, as defined by postal services.",
+                    "isVirtual": false
+                  },
+                  "RemittanceInformation": {
+                    "title": "Remittance Information",
+                    "type": "object",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "properties": {
+                      "Unstructured": {
+                        "title": "Unstructured",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form.",
+                        "minLength": 1,
+                        "maxLength": 140,
+                        "isVirtual": false
+                      },
+                      "Reference": {
+                        "title": "Reference",
+                        "type": "string",
+                        "viewable": true,
+                        "searchable": false,
+                        "userEditable": true,
+                        "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.",
+                        "minLength": 1,
+                        "maxLength": 35,
+                        "isVirtual": false
+                      }
+                    },
+                    "order": [
+                      "Unstructured",
+                      "Reference"
+                    ],
+                    "description": "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system.",
+                    "isVirtual": false
+                  },
+                  "SupplementaryData": {
+                    "title": "Supplementary Data",
+                    "type": "object",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "properties": {},
+                    "order": []
+                  }
+                },
+                "order": [
+                  "InstructionIdentification",
+                  "EndToEndIdentification",
+                  "LocalInstrument",
+                  "RequestedExecutionDateTime",
+                  "InstructedAmount",
+                  "DebtorAccount",
+                  "CreditorAccount",
+                  "CreditorPostalAddress",
+                  "RemittanceInformation",
+                  "SupplementaryData"
+                ],
+                "required": [
+                  "InstructionIdentification",
+                  "RequestedExecutionDateTime",
+                  "InstructedAmount",
+                  "CreditorAccount"
+                ],
+                "description": "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment.",
+                "isVirtual": false,
+                "nullable": false
+              },
+              "Authorisation": {
+                "title": "Authorisation",
+                "type": "object",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "properties": {
+                  "AuthorisationType": {
+                    "title": "Authorisation Type",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "Type of authorisation flow requested.",
+                    "isVirtual": false,
+                    "nullable": false
+                  },
+                  "CompletionDateTime": {
+                    "title": "Completion Date Time",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format.",
+                    "isVirtual": false
+                  }
+                },
+                "order": [
+                  "AuthorisationType",
+                  "CompletionDateTime"
+                ],
+                "required": [
+                  "AuthorisationType"
+                ],
+                "description": "Type of authorisation flow requested.",
+                "isVirtual": false
+              },
+              "SCASupportData": {
+                "title": "SCA Support Data",
+                "type": "object",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "properties": {
+                  "AppliedAuthenticationApproach": {
+                    "title": "Applied Authentication Approach",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "This field indicates whether the PSU was subject to SCA performed by the TPP",
+                    "maxLength": 40,
+                    "isVirtual": false
+                  },
+                  "ReferencePaymentOrderId": {
+                    "title": "Reference Payment Order Id",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "If the payment is recurring, then this field is populated with the transaction identifier of the previous payment occurrence so that the ASPSP can verify that the PISP, amount and the payee are the same as the previous occurrence.",
+                    "minLength": 1,
+                    "maxLength": 40,
+                    "isVirtual": false
+                  },
+                  "RequestedSCAExemptionType": {
+                    "title": "Requested SCA Exemption Type",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "This field allows a PISP to request specific SCA Exemption for a Payment Initiation",
+                    "minLength": null,
+                    "isVirtual": false
+                  }
+                },
+                "order": [
+                  "AppliedAuthenticationApproach",
+                  "ReferencePaymentOrderId",
+                  "RequestedSCAExemptionType"
+                ],
+                "description": "Supporting Data provided by TPP, when requesting SCA Exemption.",
+                "isVirtual": false
+              }
+            },
+            "order": [
+              "ConsentId",
+              "CreationDateTime",
+              "Status",
+              "StatusUpdateDateTime",
+              "ExpectedExecutionDateTime",
+              "ExpectedSettlementDateTime",
+              "CutOffDateTime",
+              "ReadRefundAccount",
+              "Permission",
+              "Charges",
+              "Initiation",
+              "Authorisation",
+              "SCASupportData"
+            ],
+            "required": [
+              "ConsentId",
+              "CreationDateTime",
+              "Status",
+              "StatusUpdateDateTime",
+              "Permission",
+              "Initiation"
+            ]
+          },
+          "Risk": {
+            "title": "Risk",
+            "type": "object",
+            "viewable": true,
+            "searchable": false,
+            "userEditable": true,
+            "properties": {
+              "PaymentContextCode": {
+                "title": "Payment Context Code",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": "Specifies the payment context",
+                "isVirtual": false
+              },
+              "MerchantCategoryCode": {
+                "title": "Merchant Category Code",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction.",
+                "minLength": 3,
+                "maxLength": 4,
+                "isVirtual": false
+              },
+              "MerchantCustomerIdentification": {
+                "title": "Merchant Customer Identification",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": "The unique customer identifier of the PSU with the merchant.",
+                "minLength": 1,
+                "maxLength": 70,
+                "isVirtual": false
+              },
+              "DeliveryAddress": {
+                "title": "Delivery Address",
+                "type": "object",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "properties": {
+                  "AddressLine": {
+                    "title": "Address Line",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text.",
+                    "minLength": 1,
+                    "maxLength": 70,
+                    "isVirtual": false
+                  },
+                  "StreetName": {
+                    "title": "Street Name",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "Name of a street or thoroughfare.",
+                    "minLength": 1,
+                    "maxLength": 70,
+                    "isVirtual": false
+                  },
+                  "BuildingNumber": {
+                    "title": "Building Number",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "Number that identifies the position of a building on a street.",
+                    "minLength": 1,
+                    "maxLength": 16,
+                    "isVirtual": false
+                  },
+                  "PostCode": {
+                    "title": "Post Code",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail.",
+                    "minLength": 1,
+                    "maxLength": 16,
+                    "isVirtual": false
+                  },
+                  "TownName": {
+                    "title": "Town Name",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "Name of a built-up area, with defined boundaries, and a local government.",
+                    "minLength": 1,
+                    "maxLength": 35,
+                    "isVirtual": false,
+                    "nullable": false
+                  },
+                  "CountrySubDivision": {
+                    "title": "Country Sub Division",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "Identifies a subdivision of a country such as state, region, county.",
+                    "minLength": 1,
+                    "maxLength": 35,
+                    "isVirtual": false
+                  },
+                  "Country": {
+                    "title": "Country",
+                    "type": "string",
+                    "viewable": true,
+                    "searchable": false,
+                    "userEditable": true,
+                    "description": "Nation with its own government, occupying a particular territory.",
+                    "isVirtual": false
+                  }
+                },
+                "order": [
+                  "AddressLine",
+                  "StreetName",
+                  "BuildingNumber",
+                  "PostCode",
+                  "TownName",
+                  "CountrySubDivision",
+                  "Country"
+                ],
+                "description": "Information that locates and identifies a specific address, as defined by postal services or in free format text.",
+                "isVirtual": false,
+                "required": [
+                  "TownName",
+                  "Country"
+                ]
+              }
+            },
+            "order": [
+              "PaymentContextCode",
+              "MerchantCategoryCode",
+              "MerchantCustomerIdentification",
+              "DeliveryAddress"
+            ],
+            "description": "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Payments.",
+            "isVirtual": false,
+            "nullable": false
+          },
+          "Links": {
+            "title": "Links",
+            "type": "object",
+            "viewable": true,
+            "searchable": false,
+            "userEditable": true,
+            "properties": {
+              "First": {
+                "title": "First",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": null,
+                "isVirtual": false
+              },
+              "Last": {
+                "title": "Last",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": null,
+                "isVirtual": false
+              },
+              "Next": {
+                "title": "Next",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": null,
+                "isVirtual": false
+              },
+              "Prev": {
+                "title": "Prev",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": null,
+                "isVirtual": false
+              },
+              "Self": {
+                "title": "Self",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": null,
+                "isVirtual": false,
+                "nullable": false
+              }
+            },
+            "order": [
+              "First",
+              "Last",
+              "Next",
+              "Prev",
+              "Self"
+            ],
+            "required": [
+              "Self"
+            ],
+            "description": "Links relevant to the payload",
+            "isVirtual": false
+          },
+          "Meta": {
+            "title": "Meta",
+            "type": "object",
+            "viewable": true,
+            "searchable": false,
+            "userEditable": true,
+            "properties": {
+              "FirstAvailableDateTime": {
+                "title": "First Available Date Time",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": "All dates in the JSON payloads are represented in ISO 8601 date-time format.",
+                "isVirtual": false
+              },
+              "LastAvailableDateTime": {
+                "title": "Last Available Date Time",
+                "type": "string",
+                "viewable": true,
+                "searchable": false,
+                "userEditable": true,
+                "description": "All dates in the JSON payloads are represented in ISO 8601 date-time format. ",
+                "isVirtual": false
+              }
+            },
+            "order": [
+              "FirstAvailableDateTime",
+              "LastAvailableDateTime",
+              "TotalPages"
+            ],
+            "required": [
+              "Self"
+            ],
+            "description": "Meta Data relevant to the payload",
+            "isVirtual": false
+          },
+          "user": {
+            "title": "User",
+            "type": "relationship",
+            "viewable": true,
+            "searchable": false,
+            "userEditable": false,
+            "returnByDefault": false,
+            "reverseRelationship": true,
+            "reversePropertyName": "domesticScheduledPaymentIntents",
+            "validate": false,
+            "properties": {
+              "_ref": {
+                "type": "string"
+              },
+              "_refProperties": {
+                "type": "object",
+                "properties": {
+                  "_id": {
+                    "type": "string",
+                    "required": false,
+                    "propName": "_id"
+                  }
+                }
+              }
+            },
+            "resourceCollection": [
+              {
+                "path": "managed/user",
+                "label": "User",
+                "query": {
+                  "queryFilter": "true",
+                  "fields": [
+                    "userName",
+                    "mail"
+                  ],
+                  "sortKeys": []
+                }
+              }
+            ],
+            "description": null
+          },
+          "apiClient": {
+            "title": "TPP Application",
+            "type": "relationship",
+            "viewable": true,
+            "searchable": false,
+            "userEditable": false,
+            "returnByDefault": false,
+            "reverseRelationship": true,
+            "reversePropertyName": "domesticScheduledPaymentIntents",
+            "validate": false,
+            "properties": {
+              "_ref": {
+                "type": "string"
+              },
+              "_refProperties": {
+                "type": "object",
+                "properties": {
+                  "_id": {
+                    "type": "string",
+                    "required": false,
+                    "propName": "_id"
+                  }
+                }
+              }
+            },
+            "resourceCollection": [
+              {
+                "path": "managed/apiClient",
+                "label": "Apiclient",
+                "query": {
+                  "queryFilter": "true",
+                  "fields": [
+                    "name"
+                  ],
+                  "sortKeys": []
+                },
+                "notify": false
+              }
+            ],
+            "description": null,
+            "requiredByParent": false,
+            "isVirtual": false,
+            "notifySelf": false,
+            "referencedRelationshipFields": null,
+            "referencedObjectFields": null,
+            "deleteQueryConfig": false
+          }
+        },
+        "order": [
+          "Data",
+          "Risk",
+          "Links",
+          "Meta",
+          "user",
+          "apiClient"
+        ],
+        "required": [
+          "Data",
+          "Risk"
+        ]
+      },
+      "iconClass": "fa fa-database",
+      "type": "Managed Object",
+      "postCreate": {
+        "type": "text/javascript",
+        "globals": {},
+        "source": "object.Data.ConsentId = object._id\nopenidm.update(resourceName.toString(),null, object)"
+      }
+    }
+  }
+]


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/250

### Implementation
Create the schema for the Domestic Scheduled Payment Intent following the [OBDomesticScheduled2](https://openbankinguk.github.io/read-write-api-site3/v3.1.8/resources-and-data-models/pisp/domestic-scheduled-payment-consents.html#domestic-scheduled-payment-consent---response) object.

The file containing the implementation is: domesticScheduledPaymentIntent.json

For now, the Charges property is added with the **type: String**. In the [issue #241](https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/241), we keep track of the Charge property not being implemented according to the specifications.

