### PR TITLE
260: Fix OAuth FAPI issues

### DIFF
--- a/config/defaults/secure-open-banking/create-base-url-source.json
+++ b/config/defaults/secure-open-banking/create-base-url-source.json
@@ -1,0 +1,12 @@
+{
+    "extensionClassName": "",
+    "source": "FIXED_VALUE",
+    "fixedValue": "https://iam.dev.forgerock.financial",
+    "contextPath": "/am",
+    "_id": "",
+    "_type": {
+        "_id": "baseurl",
+        "name": "Base URL Source",
+        "collection": false
+    }
+}

--- a/config/defaults/secure-open-banking/oauth2provider-update.json
+++ b/config/defaults/secure-open-banking/oauth2provider-update.json
@@ -13,7 +13,6 @@
   "advancedOAuth2Config": {
     "tlsClientCertificateHeaderFormat": "URLENCODED_PEM",
     "supportedSubjectTypes": [
-      "public",
       "pairwise"
     ],
     "defaultScopes": [],
@@ -55,14 +54,14 @@
     ],
     "tokenCompressionEnabled": false,
     "allowedAudienceValues": [
-      "https://obdemo.dev.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
-      "https://obdemo.nightly.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
-      "https://obdemo.andra-racovita.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
-      "https://obdemo.mariantiris.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
-      "https://obdemo.christian-brindley.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
-      "https://obdemo.bohocode.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
-      "https://obdemo.jorgesanchezperez.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token",
-      "https://obdemo.joycegilding-forgerock.forgerock.financial:443/am/oauth2/realms/root/realms/alpha/access_token"
+      "https://obdemo.dev.forgerock.financial/am/oauth2/realms/root/realms/alpha/access_token",
+      "https://obdemo.nightly.forgerock.financial/am/oauth2/realms/root/realms/alpha/access_token",
+      "https://obdemo.andra-racovita.forgerock.financial/am/oauth2/realms/root/realms/alpha/access_token",
+      "https://obdemo.mariantiris.forgerock.financial/am/oauth2/realms/root/realms/alpha/access_token",
+      "https://obdemo.christian-brindley.forgerock.financial/am/oauth2/realms/root/realms/alpha/access_token",
+      "https://obdemo.bohocode.forgerock.financial/am/oauth2/realms/root/realms/alpha/access_token",
+      "https://obdemo.jorgesanchezperez.forgerock.financial/am/oauth2/realms/root/realms/alpha/access_token",
+      "https://obdemo.joycegilding-forgerock.forgerock.financial/am/oauth2/realms/root/realms/alpha/access_token"
     ],
     "scopeImplementationClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
     "tlsCertificateRevocationCheckingEnabled": false

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func main() {
 	fmt.Println("Attempt to create OIDC claims script..")
 	id := securebanking.CreateOIDCClaimsScript(session.Cookie)
 	securebanking.UpdateOAuth2Provider(id)
+	securebanking.CreateBaseURLSourceService(session.Cookie)
 
 	time.Sleep(5 * time.Second)
 

--- a/pkg/securebanking/oauth2_test.go
+++ b/pkg/securebanking/oauth2_test.go
@@ -5,9 +5,10 @@ import (
 	"secure-banking-uk-initializer/pkg/httprest"
 	"testing"
 
+	mocks "secure-banking-uk-initializer/pkg/mocks/am"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	mocks "secure-banking-uk-initializer/pkg/mocks/am"
 )
 
 func TestFindSoftwarePublisherAgent(t *testing.T) {


### PR DESCRIPTION
The aim here is to get a working flow that is FAPI compliant. We can't
do that as yet, but this moves us to a place were at least we can get
flows working using postman. We are now in a position where the URI on
which the OAuth2 well_know response is obtained matches the issuer url
within the response. To do this we have configured the OAuth2Provider to
accept obdemo.<namespace>.forgerock.financial as an Acceptable Audience
Value. This is all good.

The current issue is that the authorize endpoint must be accessed on the
iam.<namespace> domain, but the FAPI conformance suite uses the issuer
value from the well_known namespace as the audience in the request jwt.
This is now the obdemo.<namespace> domain. :-( We don't have an easy way
to fix this.

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/260