### PR TITLE
Add AccountId in the DebtorAccount. Update policy script

### DIFF
--- a/config/defaults/secure-open-banking/managed-objects/domesticPaymentIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/domesticPaymentIntent.json
@@ -176,6 +176,16 @@
                       "searchable": false,
                       "userEditable": true,
                       "properties": {
+                        "AccountId": {
+                          "title": "Account id",
+                          "type": "string",
+                          "viewable": true,
+                          "searchable": true,
+                          "userEditable": true,
+                          "description": "Account id",
+                          "minLength": null,
+                          "isVirtual": false
+                        },
                         "SchemeName": {
                           "title": "Scheme Name",
                           "type": "string",
@@ -218,6 +228,7 @@
                         }
                       },
                       "order": [
+                        "AccountId",
                         "SchemeName",
                         "Identification",
                         "Name",

--- a/config/defaults/secure-open-banking/pisp-policy.json
+++ b/config/defaults/secure-open-banking/pisp-policy.json
@@ -3,6 +3,7 @@
   "active": true,
   "description": "",
   "resources": [
+    "https://rs.*.forgerock.financial:443/open-banking/*/pisp/domestic-payment-consents/*/funds-confirmation",
     "https://rs.*.forgerock.financial:443/open-banking/*/pisp/domestic-payments",
     "https://rs.*.forgerock.financial:443/open-banking/*/pisp/domestic-payments/*",
     "https://rs.*.forgerock.financial:443/open-banking/*/pisp/domestic-payments/*/payment-details",

--- a/config/defaults/secure-open-banking/policy-evaluation-script.js
+++ b/config/defaults/secure-open-banking/policy-evaluation-script.js
@@ -207,7 +207,7 @@ function getIdmAccessToken() {
 function findIntentType(api) {
     if (getRequestTypeAccountAndTransactions(api) != null)
         return "accountAccessIntent"
-    else if (api === "domestic-payments")
+    else if (api === "domestic-payments" || api === "domestic-payment-consents")
         return "domesticPaymentIntent"
     return null
 }

--- a/config/defaults/secure-open-banking/policy-evaluation-script.js
+++ b/config/defaults/secure-open-banking/policy-evaluation-script.js
@@ -205,10 +205,15 @@ function getIdmAccessToken() {
 }
 
 function findIntentType(api) {
-    if (getRequestTypeAccountAndTransactions(api) != null)
+    if (getRequestTypeAccountAndTransactions(api) != null) {
         return "accountAccessIntent"
-    else if (api === "domestic-payments" || api === "domestic-payment-consents")
+    }
+    else if (api === "domestic-payments" || api === "domestic-payment-consents") {
         return "domesticPaymentIntent"
+    }
+    else if (api === "domestic-scheduled-payments" || api === "domestic-scheduled-payment-consents") {
+        return "domesticScheduledPaymentIntent"
+    }
     return null
 }
 
@@ -298,7 +303,7 @@ if (intentType === "accountAccessIntent") {
             dataAuthorised(permissions, apiRequest.data)
     }
 
-} else if (intentType === "domesticPaymentIntent") {
+} else if (intentType === "domesticPaymentIntent" || intentType === "domesticScheduledPaymentIntent") {
     logger.message(script_name + ": Domestic Payments Intent");
 
     var status = intent.Data.Status


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/297

### Implementation
- Add in the Domestic Payment Intent managed object the filed accountId for the DebtorAccount. 
- Updated the policy to accept request from the funds-confirmation endpoint
- Upgrade policy evaluation script to support Domestic Scheduled payment intent. Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/277