### PR TITLE
354: update standing order intent name

### DIFF
--- a/config/defaults/secure-open-banking/managed-objects/domesticStandingOrderIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/domesticStandingOrderIntent.json
@@ -3,7 +3,7 @@
     "operation": "add",
     "field": "objects/-",
     "value": {
-      "name": "domesticStandingOrderPaymentIntent",
+      "name": "domesticStandingOrderIntent",
       "schema": {
         "$schema": "http://forgerock.org/json-schema#",
         "type": "object",
@@ -873,7 +873,7 @@
             "userEditable": false,
             "returnByDefault": false,
             "reverseRelationship": true,
-            "reversePropertyName": "domesticStandingOrderPaymentIntents",
+            "reversePropertyName": "domesticStandingOrderIntents",
             "validate": false,
             "properties": {
               "_ref": {
@@ -914,7 +914,7 @@
             "userEditable": false,
             "returnByDefault": false,
             "reverseRelationship": true,
-            "reversePropertyName": "domesticStandingOrderPaymentIntents",
+            "reversePropertyName": "domesticStandingOrderIntents",
             "validate": false,
             "properties": {
               "_ref": {

--- a/config/defaults/secure-open-banking/policy-evaluation-script.js
+++ b/config/defaults/secure-open-banking/policy-evaluation-script.js
@@ -215,7 +215,7 @@ function findIntentType(api) {
         return "domesticScheduledPaymentIntent"
     }
     else if (api === "domestic-standing-orders" || api === "domestic-standing-order-consents") {
-        return "domesticStandingOrderPaymentIntent"
+        return "domesticStandingOrderIntent"
     }
     return null
 }
@@ -313,7 +313,7 @@ if (intentType === "accountAccessIntent") {
             dataAuthorised(permissions, apiRequest.data)
     }
 
-} else if (intentType === "domesticPaymentIntent" || intentType === "domesticScheduledPaymentIntent" || intentType === "domesticStandingOrderPaymentIntent") {
+} else if (intentType === "domesticPaymentIntent" || intentType === "domesticScheduledPaymentIntent" || intentType === "domesticStandingOrderIntent") {
     logger.message(script_name + ": Domestic Payments Intent");
 
     var status = intent.Data.Status


### PR DESCRIPTION
- `domesticStandingOrderPaymentIntent` renamed to `domesticStandingOrderIntent`
- Policy script update to use the proper intent name
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/354