### PR TITLE
441: Removing environment.namespace value

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-fidc-initializer/templates/cronjob-secret.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-fidc-initializer/templates/cronjob-secret.yaml
@@ -3,7 +3,6 @@ apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
   name: initializer-secret
-  namespace: {{ .Values.environment.namespace }}
 spec:
   backendType: gcpSecretsManager
   projectId: {{ .Values.projectId }}

--- a/_infra/helm/securebanking-openbanking-uk-fidc-initializer/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-fidc-initializer/values.yaml
@@ -6,7 +6,6 @@ cron: "* * * * *"
 # FIDC value: FIDC (Forgerock Identity Cloud) identity cloud platform
 environment:
   type: FIDC
-  namespace: dev
   
   # RaiseForStatus will exit if go resty returns an error in STRICT mode,
   # be it client error, server error or other. Turning off (false)


### PR DESCRIPTION
Currently, the cronjob-secret is being created in the dev namespace (default value) for the nightly environment (because we are not overriding the value).

I think that we can simply remove the environment.namespace value and allow Argo CD to default the namespace to that of the application. i.e. All objects for the nightly application will be placed in the nightly namespace.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/441