### PR TITLE
441: Removing explicitly setting metadata.namespace

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob-secret.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob-secret.yaml
@@ -3,7 +3,6 @@ apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
   name: initializer-secret
-  namespace: {{ .Release.Namespace }}
 spec:
   backendType: gcpSecretsManager
   projectId: {{ .Values.projectId }}


### PR DESCRIPTION
Making the cronjob-secret.yaml definition consistent for both helm charts wrt allowing the namespace to be set based on the argo installation.

See PR: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer/pull/95

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/441