### PR TITLE
Update pisp-policy.json

### DIFF
--- a/config/defaults/secure-open-banking/pisp-policy.json
+++ b/config/defaults/secure-open-banking/pisp-policy.json
@@ -4,6 +4,8 @@
   "description": "",
   "resources": [
     "https://rs.{{- if .Hosts.WildcardFQDN -}}{{ .Hosts.WildcardFQDN }}{{- else -}}{{ .Hosts.BaseFQDN }}{{- end }}:443/open-banking/*/pisp/domestic-payment-consents/*/funds-confirmation",
+    "https://rs.{{- if .Hosts.WildcardFQDN -}}{{ .Hosts.WildcardFQDN }}{{- else -}}{{ .Hosts.BaseFQDN }}{{- end }}:443/open-banking/*/pisp/international-payment-consents/*/funds-confirmation",
+    "https://rs.{{- if .Hosts.WildcardFQDN -}}{{ .Hosts.WildcardFQDN }}{{- else -}}{{ .Hosts.BaseFQDN }}{{- end }}:443/open-banking/*/pisp/international-scheduled-payment-consents/*/funds-confirmation",
     "https://rs.{{- if .Hosts.WildcardFQDN -}}{{ .Hosts.WildcardFQDN }}{{- else -}}{{ .Hosts.BaseFQDN }}{{- end }}:443/open-banking/*/pisp/domestic-payments",
     "https://rs.{{- if .Hosts.WildcardFQDN -}}{{ .Hosts.WildcardFQDN }}{{- else -}}{{ .Hosts.BaseFQDN }}{{- end }}:443/open-banking/*/pisp/domestic-payments/*",
     "https://rs.{{- if .Hosts.WildcardFQDN -}}{{ .Hosts.WildcardFQDN }}{{- else -}}{{ .Hosts.BaseFQDN }}{{- end }}:443/open-banking/*/pisp/domestic-payments/*/payment-details",


### PR DESCRIPTION
Add to the pisp policy resource list the urls for funds confirmation for international payments and international scheduled payments.

```
https://rs.*.forgerock.financial:443/open-banking/*/pisp/international-payment-consents/*/funds-confirmation
https://rs.*.forgerock.financial:443/open-banking/*/pisp/international-scheduled-payment-consents/*/funds-confirmation
```