### PR TITLE
276: Allow argo to override image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.16.0
-
+RUN apk update
 RUN apk --no-cache add curl libc6-compat gcompat
 RUN addgroup -S sob-group && adduser -S sob-user -G sob-group
 

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
@@ -12,9 +12,13 @@ spec:
       template:
         spec:
           containers:
-            - name: iam-init
-              image: {{ tpl .Values.iam_initializer_image_location . }}
-              imagePullPolicy: Always
+            - name: {{ .Chart.Name }}
+              {{- if .Values.deployment.imageOverride.enabled }}
+              image: "{{ .Values.deployment.imageOverride.repo }}/{{ .Values.deployment.imageOverride.iam_initializer_image_name}}:{{ .Values.deployment.imageOverride.iam-init.tag }}"
+              {{- else }}
+              image: "eu.gcr.io/sbat-gcr-release/securebanking/{{ .Chart.Name }}:{{ .Chart.AppVersion }}"
+              {{- end }}
+              imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
               env:
                 - name: ENVIRONMENT.STRICT
                   value: {{ .Values.environment.strict | quote }}

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/values.yaml
@@ -1,4 +1,11 @@
 cron: "* * * * *"
+  
+deployment:  
+  imageOverride:
+    enabled: true
+    repo: eu.gcr.io/sbat-gcr-develop/securebanking
+    iam_initializer_image_name: secureopenbanking-uk-iam-initializer
+    tag: latest
 
 # ** Value Name:** iam_initializer_image_location
 #


### PR DESCRIPTION
So that we can deploy images built for a PR when a PR is pushed.

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/276