### PR TITLE
535: Updating accountAccessIntent IDM object structure

### DIFF
--- a/config/defaults/secure-open-banking/managed-objects/accountAccessIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/accountAccessIntent.json
@@ -38,7 +38,7 @@
               "description": "Open Banking Intent Object",
               "type": "object",
               "viewable": true,
-              "searchable": true,
+              "searchable": false,
               "userEditable": true,
               "isVirtual": false,
               "nullable": false,

--- a/config/defaults/secure-open-banking/managed-objects/accountAccessIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/accountAccessIntent.json
@@ -11,110 +11,148 @@
           "description": "Account Access Intent",
           "icon": "fa-money",
           "properties": {
-            "Data": {
-              "title": "Data",
-              "type": "object",
+            "OBVersion": {
+              "title": "OB Version",
+              "description": "Open Banking API Version used to create this object",
+              "type": "string",
               "viewable": true,
-              "searchable": false,
-              "userEditable": true,
-              "properties": {
-                "ConsentId": {
-                  "title": "Account Access Consent Id",
-                  "type": "string",
-                  "viewable": true,
-                  "searchable": true,
-                  "userEditable": true,
-                  "description": null,
-                  "minLength": null,
-                  "isVirtual": false
-                },
-                "CreationDateTime": {
-                  "title": "Creation Date Time",
-                  "type": "string",
-                  "viewable": true,
-                  "searchable": true,
-                  "userEditable": true
-                },
-                "Status": {
-                  "title": "Account Access Status",
-                  "type": "string",
-                  "viewable": true,
-                  "searchable": true,
-                  "userEditable": true
-                },
-                "StatusUpdateDateTime": {
-                  "title": "Status Update Date Time",
-                  "type": "string",
-                  "viewable": true,
-                  "searchable": true,
-                  "userEditable": true,
-                  "description": null,
-                  "minLength": null,
-                  "isVirtual": false
-                },
-                "Permissions": {
-                  "title": "Permission",
-                  "type": "array",
-                  "viewable": true,
-                  "searchable": false,
-                  "userEditable": true,
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "ExpirationDateTime": {
-                  "title": "Expiration Date Time",
-                  "type": "string",
-                  "viewable": true,
-                  "searchable": false,
-                  "userEditable": true,
-                  "description": null,
-                  "minLength": null,
-                  "isVirtual": false
-                },
-                "TransactionFromDateTime": {
-                  "title": "Transaction From Date Time",
-                  "type": "string",
-                  "viewable": true,
-                  "searchable": false,
-                  "userEditable": true,
-                  "description": null,
-                  "minLength": null,
-                  "isVirtual": false
-                },
-                "TransactionToDateTime": {
-                  "title": "Transaction To Date Time",
-                  "type": "string",
-                  "viewable": true,
-                  "searchable": false,
-                  "userEditable": true,
-                  "description": null,
-                  "minLength": null,
-                  "isVirtual": false
-                }
-              },
-              "order": [
-                "ConsentId",
-                "CreationDateTime",
-                "Status",
-                "StatusUpdateDateTime",
-                "Permissions",
-                "ExpirationDateTime",
-                "TransactionFromDateTime",
-                "TransactionToDateTime"
-              ],
-              "description": null,
-              "isVirtual": false,
+              "searchable": true,
+              "userEditable": false,
+              "minLength": 1,
+              "maxLength": 16,
               "nullable": false
             },
-            "Risk": {
-              "title": "Risk",
+            "OBIntentObjectType": {
+              "title": "OB Intent Object Type",
+              "description": "Open Banking API Intent Object Type",
+              "type": "string",
+              "viewable": true,
+              "searchable": true,
+              "userEditable": false,
+              "minLength": 1,
+              "maxLength": 128,
+              "nullable": false
+            },
+            "OBIntentObject": {
+              "title": "OB Intent",
+              "description": "Open Banking Intent Object",
               "type": "object",
               "viewable": true,
-              "searchable": false,
+              "searchable": true,
               "userEditable": true,
-              "properties": {},
-              "order": []
+              "isVirtual": false,
+              "nullable": false,
+              "properties": {
+                "Data": {
+                  "title": "Data",
+                  "type": "object",
+                  "viewable": true,
+                  "searchable": false,
+                  "userEditable": true,
+                  "properties": {
+                    "ConsentId": {
+                      "title": "Account Access Consent Id",
+                      "type": "string",
+                      "viewable": true,
+                      "searchable": true,
+                      "userEditable": true,
+                      "description": null,
+                      "minLength": null,
+                      "isVirtual": false
+                    },
+                    "CreationDateTime": {
+                      "title": "Creation Date Time",
+                      "type": "string",
+                      "viewable": true,
+                      "searchable": true,
+                      "userEditable": true
+                    },
+                    "Status": {
+                      "title": "Account Access Status",
+                      "type": "string",
+                      "viewable": true,
+                      "searchable": true,
+                      "userEditable": true
+                    },
+                    "StatusUpdateDateTime": {
+                      "title": "Status Update Date Time",
+                      "type": "string",
+                      "viewable": true,
+                      "searchable": true,
+                      "userEditable": true,
+                      "description": null,
+                      "minLength": null,
+                      "isVirtual": false
+                    },
+                    "Permissions": {
+                      "title": "Permission",
+                      "type": "array",
+                      "viewable": true,
+                      "searchable": false,
+                      "userEditable": true,
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "ExpirationDateTime": {
+                      "title": "Expiration Date Time",
+                      "type": "string",
+                      "viewable": true,
+                      "searchable": false,
+                      "userEditable": true,
+                      "description": null,
+                      "minLength": null,
+                      "isVirtual": false
+                    },
+                    "TransactionFromDateTime": {
+                      "title": "Transaction From Date Time",
+                      "type": "string",
+                      "viewable": true,
+                      "searchable": false,
+                      "userEditable": true,
+                      "description": null,
+                      "minLength": null,
+                      "isVirtual": false
+                    },
+                    "TransactionToDateTime": {
+                      "title": "Transaction To Date Time",
+                      "type": "string",
+                      "viewable": true,
+                      "searchable": false,
+                      "userEditable": true,
+                      "description": null,
+                      "minLength": null,
+                      "isVirtual": false
+                    }
+                  },
+                  "order": [
+                    "ConsentId",
+                    "CreationDateTime",
+                    "Status",
+                    "StatusUpdateDateTime",
+                    "Permissions",
+                    "ExpirationDateTime",
+                    "TransactionFromDateTime",
+                    "TransactionToDateTime"
+                  ],
+                  "description": null,
+                  "isVirtual": false,
+                  "nullable": false
+                },
+                "Risk": {
+                  "title": "Risk",
+                  "type": "object",
+                  "viewable": true,
+                  "searchable": false,
+                  "userEditable": true,
+                  "properties": {},
+                  "order": []
+                }
+              },
+              "required": [
+                "Data",
+                "Risk"
+              ]
             },
             "user": {
               "title": "User",
@@ -219,15 +257,17 @@
             }
           },
           "order": [
-            "Data",
-            "Risk",
+            "OBVersion",
+            "OBIntentObjectType",
+            "OBIntentObject",
             "user",
             "apiClient",
             "accounts"
           ],
           "required": [
-            "Data",
-            "Risk"
+            "OBIntentObjectType",
+            "OBVersion",
+            "OBIntentObject"
           ]
         },
         "iconClass": "fa fa-database",
@@ -235,7 +275,7 @@
         "postCreate": {
           "type": "text/javascript",
           "globals": {},
-          "source": "object.Data.ConsentId = object._id\nopenidm.update(resourceName.toString(),null, object)"
+          "source": "object.OBIntentObject.Data.ConsentId = object._id\nopenidm.update(resourceName.toString(),null, object)"
         }
       }
     }

--- a/config/defaults/secure-open-banking/managed-objects/accountAccessIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/accountAccessIntent.json
@@ -125,6 +125,10 @@
                       "isVirtual": false
                     }
                   },
+                  "required": [
+                    "ConsentId",
+                    "Status"
+                  ],
                   "order": [
                     "ConsentId",
                     "CreationDateTime",

--- a/config/defaults/secure-open-banking/policy-evaluation-script.js
+++ b/config/defaults/secure-open-banking/policy-evaluation-script.js
@@ -217,7 +217,14 @@ function findIntentType(api) {
 function getIntent(intentId, intentType) {
     var accessToken = getIdmAccessToken();
     var request = new org.forgerock.http.protocol.Request();
-    var uri = "http://idm/openidm/managed/" + intentType + "/" + intentId + "?_fields=_id,_rev,Data,Risk,user/_id,accounts,apiClient/_id"
+
+    // Account Access Intent IDM schema has been restructured, therefore query fields are different
+    var uri
+    if (intentType === "accountAccessIntent") {
+        uri = "http://idm/openidm/managed/accountAccessIntent/" + intentId + "?_fields=_id,_rev,OBIntentObject,user/_id,accounts,apiClient/_id"
+    } else {
+        uri = "http://idm/openidm/managed/" + intentType + "/" + intentId + "?_fields=_id,_rev,Data,Risk,user/_id,accounts,apiClient/_id"
+    }
     logger.message(script_name + ": IDM fetch " + uri)
 
     request.setMethod('GET');
@@ -272,8 +279,9 @@ var intent = getIntent(intentId, intentType);
 if (intentType === "accountAccessIntent") {
     logger.message(script_name + ": Account Access Intent");
 
-    var status = intent.Data.Status
-    var permissions = intent.Data.Permissions
+    var obIntentObj = intent.OBIntentObject
+    var status = obIntentObj.Data.Status
+    var permissions = obIntentObj.Data.Permissions
     var accounts = intent.accounts
     // The responseAttributes expected always and array as value
     var userResourceOwner = new Array(intent.user._id)


### PR DESCRIPTION
- New structure adds OBIntentObject field, which is an object that matches the OB API type OBReadConsentResponse1
- OBVersion and OBIntentObjectType metadata fields which represent the OB API version used to create the intent and the OB Schema type of the intent i.e. OBReadConsentResponse1 in this case.
- Made OBIntentObject.Data.ConsentId and OBIntentObject.Data.Status fields mandatory
- Updating policy-evaluation-script.js to query this new structure from IDM

https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/535