### PR TITLE
589: update IDM intent file payments intent to store the file content

### DIFF
--- a/config/defaults/secure-open-banking/managed-objects/filePaymentsIntent.json
+++ b/config/defaults/secure-open-banking/managed-objects/filePaymentsIntent.json
@@ -563,6 +563,12 @@
             "description": "Account id",
             "minLength": null,
             "isVirtual": false
+          },
+          "FileContent": {
+            "title": "File content",
+            "type": "string",
+            "description": "File content",
+            "isVirtual": false
           }
         },
         "order": [


### PR DESCRIPTION
- Added `FileContent` field to store the file content
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/589