### PR TITLE
615: Give initialiser templating access to the IG FQDN

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,3 +35,16 @@ jobs:
       - name: docker build
         run: |
           make docker tag=${{ env.PR_NUMBER }}
+
+      - name: Create lowercase Github Username
+        id: toLowerCase
+        run: echo "GITHUB_USER=$(echo ${{github.actor}} | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}
+
+      - name: 'Deploy Service'
+        uses: codefresh-io/codefresh-pipeline-runner@master
+        with:
+          args: '-v TAG=${{ env.PR_NUMBER }} -v SERVICE_NAME=iam-initialiser -v ENVIRONMENT=${{ env.GITHUB_USER }} -v BRANCH=${{ github.head_ref }}'
+        env:
+          PIPELINE_NAME: 'ForgeCloud/sbat-infra/service-build'
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+        id: run-pipeline

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
@@ -32,6 +32,11 @@ spec:
                     configMapKeyRef:
                       name: securebanking-platform-config
                       key: IDENTITY_PLATFORM_FQDN
+                - name: HOSTS.IG_FQDN
+                  valueFrom:
+                    configMapKeyRef:
+                      name: securebanking-platform-config
+                      key: IG_FQDN
                 - name: HOSTS.IDENTITY_PLATFORM_FQDN
                   valueFrom:
                     configMapKeyRef:


### PR DESCRIPTION
This is necessary because if we set AM to properly use the IG_FQDN then we will need to use IG_FQDN to do some AM config templating, for example the issuer of the access_tokens will now be the IG_FQDN. THis is the cause of issue 615.

Also added to the pr workflow so that when an initialise PR is pushed the initialiser (with PR tag) gets deployed to the developers dev env.

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/615