### PR TITLE
622: OB Spec states only PS256 for signing algos

### DIFF
--- a/config/defaults/secure-open-banking/oauth2provider-update.json
+++ b/config/defaults/secure-open-banking/oauth2provider-update.json
@@ -85,17 +85,15 @@
       "A256CBC-HS512"
     ],
     "supportedIDTokenSigningAlgorithms": [
-      "PS256",
-      "ES256"        ]
+      "PS256"
+    ]
   },
   "advancedOIDCConfig": {
     "supportedTokenIntrospectionResponseSigningAlgorithms": [
-      "PS256",
-      "ES256"
+      "PS256"
     ],
     "supportedRequestParameterSigningAlgorithms": [
-      "PS256",      
-      "ES256"
+      "PS256"
     ],
     "idTokenInfoClientAuthenticationEnabled": true,
     "alwaysAddClaimsToToken": true,
@@ -104,8 +102,7 @@
       "urn:openbanking:psd2:ca": "PSD2CustomerAuthentication"
     },
     "supportedTokenEndpointAuthenticationSigningAlgorithms": [
-      "PS256",
-      "ES256"
+      "PS256"
     ],
     "supportedRequestParameterEncryptionAlgorithms": [
       "ECDH-ES+A256KW",
@@ -153,8 +150,7 @@
       "A256CBC-HS512"
     ],
     "supportedUserInfoSigningAlgorithms": [
-      "PS256",
-      "ES256"
+      "PS256"
     ],
     "supportedTokenIntrospectionResponseEncryptionEnc": [
       "A256GCM",
@@ -187,8 +183,7 @@
   },
   "cibaConfig": {
     "supportedCibaSigningAlgorithms": [
-      "PS256",
-      "ES256"
+      "PS256"
     ],
     "cibaAuthReqIdLifetime": 600,
     "cibaMinimumPollingInterval": 2
@@ -196,8 +191,7 @@
   "consent": {
     "clientsCanSkipConsent": false,
     "supportedRcsRequestSigningAlgorithms": [
-      "RS256",
-      "ES256"
+      "RS256"
     ],
     "supportedRcsRequestEncryptionMethods": [
       "A256GCM",
@@ -220,8 +214,7 @@
       "A192KW"
     ],
     "supportedRcsResponseSigningAlgorithms": [
-      "RS256",      
-      "ES256"
+      "RS256"
     ],
     "enableRemoteConsent": true,
     "supportedRcsResponseEncryptionAlgorithms": [

--- a/config/defaults/secure-open-banking/oauth2provider-update.json
+++ b/config/defaults/secure-open-banking/oauth2provider-update.json
@@ -214,7 +214,7 @@
       "A192KW"
     ],
     "supportedRcsResponseSigningAlgorithms": [
-      "RS256"
+      "PS256"
     ],
     "enableRemoteConsent": true,
     "supportedRcsResponseEncryptionAlgorithms": [

--- a/config/defaults/secure-open-banking/oauth2provider-update.json
+++ b/config/defaults/secure-open-banking/oauth2provider-update.json
@@ -191,7 +191,7 @@
   "consent": {
     "clientsCanSkipConsent": false,
     "supportedRcsRequestSigningAlgorithms": [
-      "RS256"
+      "PS256"
     ],
     "supportedRcsRequestEncryptionMethods": [
       "A256GCM",


### PR DESCRIPTION
Ideally we would be able to apply a default FAPI config, and then an 'overlay' for OB specifics or customer specifics etc.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/622