### PR TITLE
621: Removing the unique constraint from apiClient.ssa field

### DIFF
--- a/config/defaults/secure-open-banking/managed-objects/apiClient.json
+++ b/config/defaults/secure-open-banking/managed-objects/apiClient.json
@@ -67,13 +67,7 @@
               "userEditable": true,
               "description": null,
               "minLength": null,
-              "isVirtual": false,
-              "policies": [
-                {
-                  "policyId": "unique",
-                  "params": {}
-                }
-              ]
+              "isVirtual": false
             },
             "apiClientOrg": {
               "title": "API Client Organisation",
@@ -233,7 +227,7 @@
             "domesticPaymentIntents",
             "accountAccessIntents"
           ],
-          "required": [],
+          "required": ["id", "name", "oauth2ClientId","ssa"],
           "mat-icon": null
         },
         "iconClass": "fa fa-database",


### PR DESCRIPTION
There is no requirement in the spec that an ssa needs to be unique, multiple apiClients should be able to reference the same ssa.

In our current environments this is the case, as we have a bug where the ssa field is not being set. In order to fix that bug we need to disable the unique constraint.

Also doing some cleanup to make the id, name, oauth2ClientId and ssa required fields.

https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/621