### PR TITLE
259: Remove un-necessary allowed audience values

### DIFF
--- a/config/defaults/secure-open-banking/oauth2provider-update.json
+++ b/config/defaults/secure-open-banking/oauth2provider-update.json
@@ -51,7 +51,9 @@
       "id_token|org.forgerock.openidconnect.IdTokenResponseTypeHandler"
     ],
     "tokenCompressionEnabled": false,
-    "allowedAudienceValues": [],
+    "allowedAudienceValues": [
+      "https://{{.Hosts.IgFQDN}}:443/am/oauth2/realms/root/realms/alpha/access_token"
+    ],
     "scopeImplementationClass": "org.forgerock.openam.oauth2.OpenAMScopeValidator",
     "tlsCertificateRevocationCheckingEnabled": false
   },

--- a/config/viper/viper-default-configuration.yaml
+++ b/config/viper/viper-default-configuration.yaml
@@ -19,6 +19,7 @@ HOSTS:
   BASE_FQDN: dev.forgerock.financial
   WILDCARD_FQDN: "*.forgerock.financial" # If set allows resources in AISP/PISP access to RC/RCS in all subdomains
   IDENTITY_PLATFORM_FQDN: iam.dev.forgerock.financial # Identity platform Host name
+  IG_FQDN: obdemo.dev.forgerock.financial  
   RCS_UI_FQDN: rcs-ui.dev.forgerock.financial # RCS user interface app host name (Consent user app)
   SCHEME: https # URI scheme, Syntax part of a generic URI
   IG_AUDIENCE_FQDNS:


### PR DESCRIPTION
We previously had allowed audience values for all environments in the OAuth2Provider config. Now we can template config pushed to a specific CDK to have only the required allowed audience value.

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/259