### PR TITLE
658: Creating Validation Service in AM

### DIFF
--- a/config/defaults/secure-open-banking/create-validation-service.json
+++ b/config/defaults/secure-open-banking/create-validation-service.json
@@ -1,0 +1,11 @@
+{
+  "validGotoDestinations": [
+    "https://{{.Hosts.IdentityPlatformFQDN}}/*?*",
+    "https://{{.Hosts.IgFQDN}}/am/*?*"
+  ],
+  "_type": {
+    "_id": "validation",
+    "name": "Validation Service",
+    "collection": false
+  }
+}

--- a/main.go
+++ b/main.go
@@ -75,6 +75,9 @@ func main() {
 	fmt.Println("Attempting to configure AM CORS Service")
 	securebanking.ConfigureAmCorsService(session.Cookie)
 
+	fmt.Println("Attempting to create AM Validation Service")
+	securebanking.CreateAmValidationService(session.Cookie)
+
 	fmt.Println("Attempt PSD2 authentication trees initialization...")
 	securebanking.CreateSecureBankingPSD2AuthenticationTrees()
 	fmt.Println("Attempt to create secure banking remote consent...")

--- a/pkg/securebanking/validation_service.go
+++ b/pkg/securebanking/validation_service.go
@@ -1,0 +1,36 @@
+package securebanking
+
+import (
+	"fmt"
+	"go.uber.org/zap"
+	"net/http"
+	"secure-banking-uk-initializer/pkg/common"
+)
+
+func CreateAmValidationService(cookie *http.Cookie) {
+	zap.L().Info("Creating Validation Service")
+
+	var validationServiceConfig map[string]interface{}
+	common.Unmarshal(common.Config.Environment.Paths.ConfigSecureBanking+"create-validation-service.json", &common.Config, &validationServiceConfig)
+	path := fmt.Sprintf("https://%s/am/json/realms/root/realms/%s/realm-config/services/validation?_action=create",
+		common.Config.Hosts.IdentityPlatformFQDN, common.Config.Identity.AmRealm)
+
+	resp, err := restClient.R().
+		SetHeader("Accept", "*/*").
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Connection", "keep-alive").
+		SetHeader("X-Requested-With", "XMLHttpRequest").
+		SetHeader("Accept-API-Version", "protocol=1.0,resource=1.0").
+		SetContentLength(true).
+		SetCookie(cookie).
+		SetBody(validationServiceConfig).
+		Post(path)
+
+	zap.S().Info("resp is " + resp.String())
+	if resp != nil && resp.StatusCode() == 409 {
+		zap.S().Info("Validation Service configuration already exists")
+	} else {
+		common.RaiseForStatus(err, resp.Error(), resp.StatusCode())
+		zap.S().Info("Created Validation Service")
+	}
+}


### PR DESCRIPTION
The Validation Service is used to validate that supplied redirect urls are to valid destinations. The initial configuration allows redirects to any AM url and to the IG /am route.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/658