### PR TITLE
629: Adding x-forgerock-transactionid header to cors accept list

### DIFF
--- a/config/defaults/secure-open-banking/cors-login-ui.json
+++ b/config/defaults/secure-open-banking/cors-login-ui.json
@@ -39,7 +39,8 @@
     "sec-fetch-user",
     "upgrade-insecure-requests",
     "authorization",
-    "x-requested-with"
+    "x-requested-with",
+    "x-forgerock-transactionid"
   ],
   "exposedHeaders": [
     "Cache-Control",


### PR DESCRIPTION
After updating to AM 7.2.0, CORS filter was denying our requests.

In the AM logs we could see: "CORS Fail - Pre-flight request contained the Access-Control-Request-Headers header with an invalid value 'x-forgerock-transactionid'"

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/629