### PR TITLE
667: Configuring AM cookie domain

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-fidc-initializer/templates/configmap.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-fidc-initializer/templates/configmap.yaml
@@ -4,6 +4,7 @@ kind: ConfigMap
 metadata:
   name: securebanking-platform-config
 data:
+  BASE_FQDN: dev.forgerock.financial
   IG_FQDN: obdemo.dev.forgerock.financial
   IDENTITY_PLATFORM_FQDN: iam.dev.forgerock.financial
   # CDK value: (Cloud Developer's Kit) development identity platform

--- a/_infra/helm/securebanking-openbanking-uk-fidc-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-fidc-initializer/templates/cronjob.yaml
@@ -28,6 +28,11 @@ spec:
                     configMapKeyRef:
                       name: securebanking-platform-config
                       key: IDENTITY_PLATFORM_FQDN
+                - name: HOSTS.BASE_FQDN
+                  valueFrom:
+                    configMapKeyRef:
+                      name: securebanking-platform-config
+                      key: BASE_FQDN
                 - name: HOSTS.IDENTITY_PLATFORM_FQDN
                   valueFrom:
                     configMapKeyRef:

--- a/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-iam-initializer/templates/cronjob.yaml
@@ -32,6 +32,11 @@ spec:
                     configMapKeyRef:
                       name: securebanking-platform-config
                       key: IDENTITY_PLATFORM_FQDN
+                - name: HOSTS.BASE_FQDN
+                  valueFrom:
+                    configMapKeyRef:
+                      name: securebanking-platform-config
+                      key: BASE_FQDN
                 - name: HOSTS.IG_FQDN
                   valueFrom:
                     configMapKeyRef:

--- a/config/defaults/secure-open-banking/global-services-platform.json
+++ b/config/defaults/secure-open-banking/global-services-platform.json
@@ -1,0 +1,12 @@
+{
+  "cookieDomains": [
+    "{{.Hosts.BaseFQDN}}"
+  ],
+  "locale": "en_US",
+  "_id": "",
+  "_type": {
+    "_id": "platform",
+    "name": "Platform",
+    "collection": false
+  }
+}

--- a/main.go
+++ b/main.go
@@ -78,6 +78,9 @@ func main() {
 	fmt.Println("Attempting to create AM Validation Service")
 	securebanking.CreateAmValidationService(session.Cookie)
 
+	fmt.Println("Attempting to configure AM Global Services Platform")
+	securebanking.ConfigureAmPlatformService(session.Cookie)
+
 	fmt.Println("Attempt PSD2 authentication trees initialization...")
 	securebanking.CreateSecureBankingPSD2AuthenticationTrees()
 	fmt.Println("Attempt to create secure banking remote consent...")

--- a/pkg/securebanking/cors_service.go
+++ b/pkg/securebanking/cors_service.go
@@ -9,29 +9,7 @@ import (
 
 func ConfigureAmCorsService(cookie *http.Cookie) {
 	zap.L().Info("Configuring CORS")
-
-	var corsConfig map[string]interface{}
-	common.Unmarshal(common.Config.Environment.Paths.ConfigSecureBanking+"cors-login-ui.json", &common.Config, &corsConfig)
-	path := fmt.Sprintf("https://%s/am/json/global-config/services/CorsService/configuration?_action=create", common.Config.Hosts.IdentityPlatformFQDN)
-
-	var responsePayload map[string]interface{}
-	resp, err := restClient.R().
-		SetHeader("Accept", "*/*").
-		SetHeader("Content-Type", "application/json").
-		SetHeader("Connection", "keep-alive").
-		SetHeader("X-Requested-With", "XMLHttpRequest").
-		SetHeader("Accept-API-Version", "protocol=1.0,resource=1.0").
-		SetContentLength(true).
-		SetCookie(cookie).
-		SetBody(corsConfig).
-		SetResult(&responsePayload).
-		Post(path)
-
-	zap.S().Info("resp is " + resp.String())
-	if resp != nil && resp.StatusCode() == 409 {
-		zap.S().Info("CORS Service configuration already exists")
-	} else {
-		common.RaiseForStatus(err, resp.Error(), resp.StatusCode())
-		zap.S().Info("Created CORS Service configuration, _id: ", responsePayload["_id"])
-	}
+	CreateCrestResourceFromConfigFile(fmt.Sprintf("https://%s/am/json/global-config/services/CorsService/configuration?_action=create",
+		common.Config.Hosts.IdentityPlatformFQDN),
+		"cors-login-ui.json", cookie)
 }

--- a/pkg/securebanking/crest_resource_creator.go
+++ b/pkg/securebanking/crest_resource_creator.go
@@ -1,0 +1,54 @@
+package securebanking
+
+import (
+	"fmt"
+	"github.com/go-resty/resty/v2"
+	"go.uber.org/zap"
+	"net/http"
+	"secure-banking-uk-initializer/pkg/common"
+)
+
+func CreateCrestResourceFromConfigFile(url string, configFileName string, cookie *http.Cookie) {
+	CreateOrUpdateCrestResourceFromConfigFile(resty.MethodPost, url, configFileName, cookie)
+}
+
+func UpdateCrestResourceFromConfigFile(url string, configFileName string, cookie *http.Cookie) {
+	CreateOrUpdateCrestResourceFromConfigFile(resty.MethodPut, url, configFileName, cookie)
+}
+
+// CreateOrUpdateCrestResourceFromConfigFile
+// Generic method for creating or updating resources using the FR Crest API
+// Accepts a target CREST url to create or update the resource, and the name of a json config file to unmarshall.
+//
+// This method is suitable when the config is complete with only template value substitution, it will not work when the
+// config needs to be edited post unmarshalling e.g. to set an id value to that of a resource created in a previous step.
+func CreateOrUpdateCrestResourceFromConfigFile(httpMethod string, url string, configFileName string, cookie *http.Cookie) {
+	zap.L().Info("Attempting to create resource using CREST, url: " + httpMethod + ", configFileName: " + configFileName)
+
+	var jsonConfig map[string]interface{}
+	err := common.Unmarshal(common.Config.Environment.Paths.ConfigSecureBanking+configFileName, &common.Config, &jsonConfig)
+	if err != nil {
+		zap.S().Fatalw(fmt.Sprintf("Failed to log jsonConfig: %s , error: %v", configFileName, err))
+	}
+
+	var responsePayload map[string]interface{}
+	resp, err := restClient.R().
+		SetHeader("Accept", "*/*").
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Connection", "keep-alive").
+		SetHeader("X-Requested-With", "XMLHttpRequest").
+		SetHeader("Accept-API-Version", "protocol=1.0,resource=1.0").
+		SetContentLength(true).
+		SetCookie(cookie).
+		SetBody(jsonConfig).
+		SetResult(&responsePayload).
+		Execute(httpMethod, url)
+
+	zap.S().Info("resp is " + resp.String())
+	if resp != nil && resp.StatusCode() == 409 {
+		zap.S().Info("Nothing created, resource already exists for url: " + url + " , configFileName: " + configFileName)
+	} else {
+		common.RaiseForStatus(err, resp.Error(), resp.StatusCode())
+		zap.S().Info("Created resource, _id: ", responsePayload["_id"])
+	}
+}

--- a/pkg/securebanking/crest_resource_creator.go
+++ b/pkg/securebanking/crest_resource_creator.go
@@ -23,7 +23,7 @@ func UpdateCrestResourceFromConfigFile(url string, configFileName string, cookie
 // This method is suitable when the config is complete with only template value substitution, it will not work when the
 // config needs to be edited post unmarshalling e.g. to set an id value to that of a resource created in a previous step.
 func CreateOrUpdateCrestResourceFromConfigFile(httpMethod string, url string, configFileName string, cookie *http.Cookie) {
-	zap.L().Info("Attempting to create resource using CREST, url: " + httpMethod + ", configFileName: " + configFileName)
+	zap.L().Info("Attempting to create resource using CREST, url: " + url + ", configFileName: " + configFileName)
 
 	var jsonConfig map[string]interface{}
 	err := common.Unmarshal(common.Config.Environment.Paths.ConfigSecureBanking+configFileName, &common.Config, &jsonConfig)

--- a/pkg/securebanking/platform_service.go
+++ b/pkg/securebanking/platform_service.go
@@ -1,0 +1,14 @@
+package securebanking
+
+import (
+	"fmt"
+	"go.uber.org/zap"
+	"net/http"
+	"secure-banking-uk-initializer/pkg/common"
+)
+
+func ConfigureAmPlatformService(cookie *http.Cookie) {
+	zap.L().Info("Configuring AM Global Services Platform")
+	UpdateCrestResourceFromConfigFile(fmt.Sprintf("https://%s/am/json/global-config/services/platform",
+		common.Config.Hosts.IdentityPlatformFQDN), "global-services-platform.json", cookie)
+}

--- a/pkg/securebanking/validation_service.go
+++ b/pkg/securebanking/validation_service.go
@@ -10,27 +10,7 @@ import (
 func CreateAmValidationService(cookie *http.Cookie) {
 	zap.L().Info("Creating Validation Service")
 
-	var validationServiceConfig map[string]interface{}
-	common.Unmarshal(common.Config.Environment.Paths.ConfigSecureBanking+"create-validation-service.json", &common.Config, &validationServiceConfig)
-	path := fmt.Sprintf("https://%s/am/json/realms/root/realms/%s/realm-config/services/validation?_action=create",
+	createValidationServiceUrl := fmt.Sprintf("https://%s/am/json/realms/root/realms/%s/realm-config/services/validation?_action=create",
 		common.Config.Hosts.IdentityPlatformFQDN, common.Config.Identity.AmRealm)
-
-	resp, err := restClient.R().
-		SetHeader("Accept", "*/*").
-		SetHeader("Content-Type", "application/json").
-		SetHeader("Connection", "keep-alive").
-		SetHeader("X-Requested-With", "XMLHttpRequest").
-		SetHeader("Accept-API-Version", "protocol=1.0,resource=1.0").
-		SetContentLength(true).
-		SetCookie(cookie).
-		SetBody(validationServiceConfig).
-		Post(path)
-
-	zap.S().Info("resp is " + resp.String())
-	if resp != nil && resp.StatusCode() == 409 {
-		zap.S().Info("Validation Service configuration already exists")
-	} else {
-		common.RaiseForStatus(err, resp.Error(), resp.StatusCode())
-		zap.S().Info("Created Validation Service")
-	}
+	CreateCrestResourceFromConfigFile(createValidationServiceUrl, "create-validation-service.json", cookie)
 }


### PR DESCRIPTION
The Cookie domain needs to be configured in order for the cookie to be sent to IG when we are using it to reverse proxy AM.

 - Cookie domain is configured via the Platform Global Service
 - Cookie domain is configured to be the BASE_FQDN of the environment e.g. dev.forgerock.financial for dev env
 - Extracted common func to create or update resources using AM CREST API, using this for cors and validation service creation as well

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/667